### PR TITLE
[CAS-92] Update Preprints: ASU -> LiveData

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -13,7 +13,7 @@ agrixiv:
   id: '203948234207244'
   name: AgriXiv Preprints
   domain: agrixiv.org
-asu:
+livedata:
   id: '203948234207254'
   name: LiveData
 bitss:


### PR DESCRIPTION
### Purpose

`id` change for Preprints LiveData (formerly ASU)

### Related CAS PR

https://github.com/CenterForOpenScience/cas-overlay/pull/87
