### PR TITLE
[OSF Preprints] [CAS] Add domain for MarXiv, EarthArXiv and PaleorXiv [No Ticket]

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -23,6 +23,7 @@ bitss:
 eartharxiv:
   id: '203948234207261'
   name: EarthArXiv Preprints
+  domain: eartharxiv.org
 engrxiv:
   id: '203948234207242'
   name: engrXiv Preprints
@@ -55,6 +56,7 @@ livedata:
 marxiv:
   id: '203948234207260'
   name: MarXiv Papers
+  domain: marxiv.org
 medarxiv:
   id: '203948234207256'
   name: MedArXiv Preprints
@@ -68,6 +70,7 @@ nutrixiv:
 paleorxiv:
   id: '203948234207251'
   name: PaleorXiv Preprints
+  domain: paleorxiv.org
 psyarxiv:
   id: '203948234207243'
   name: PsyArXiv Preprints


### PR DESCRIPTION
@binoculars, thanks! 🎆 

FYI, a useful API:
https://api.osf.io/v2/preprint_providers/=?filter%5Bdomain_redirect_enabled%5D=True