### PR TITLE
Fix toleration array

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -68,7 +68,7 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `client.resources`                        | Client node resources requests & limits                             | `{} - cpu limit must be an integer`                 |
 | `client.heapSize`                         | Client node heap size                                               | `512m`                                              |
 | `client.podAnnotations`                   | Client deployment annotations                                       | `{}`                                                |
-| `client.tolerations`                      | Client toleration policy                                            | `{}`                                                |
+| `client.tolerations`                      | Client toleration policy                                            | `[]`                                                |
 | `client.service.annotations`              | Client service annotations                                          | `{}`                                                |
 | `client.service.type`                     | Client service type                                                 | `ClusterIP`                                         |
 | `client.service.loadBalancerIP`           | Client service load balancer ip                                     | `nil`                                               |
@@ -87,7 +87,7 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `master.persistence.size`                 | Master persistent volume size                                       | `4Gi`                                               |
 | `master.persistence.storageClass`         | Master persistent volume Class                                      | `nil`                                               |
 | `master.persistence.accessMode`           | Master persistent Access Mode                                       | `ReadWriteOnce`                                     |
-| `master.tolerations`                      | Data toleration policy                                              | `{}`                                                |
+| `master.tolerations`                      | Data toleration policy                                              | `[]`                                                |
 | `data.exposeHttp`                         | Expose http port 9200 on data Pods for monitoring, etc              | `false`                                             |
 | `data.replicas`                           | Data node replicas (statefulset)                                    | `2`                                                 |
 | `data.resources`                          | Data node resources requests & limits                               | `{} - cpu limit must be an integer`                 |
@@ -100,7 +100,7 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `data.podAnnotations`                     | Data StatefulSet annotations                                        | `{}`                                                |
 | `data.terminationGracePeriodSeconds`      | Data termination grace period (seconds)                             | `3600`                                              |
 | `data.antiAffinity`                       | Data anti-affinity policy                                           | `soft`                                              |
-| `data.tolerations`                        | Data toleration policy                                              | `{}`                                                |
+| `data.tolerations`                        | Data toleration policy                                              | `[]`                                                |
 | `rbac.create`                             | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                                             |
 | `plugins.enabled`                         | Plugins management                                                  | `false`                                             |
 | `plugins.install`                         | Plugins to install on pod initialization                            | `[]`                                                |

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -91,7 +91,7 @@ client:
   #             operator: In
   #             values:
   #               - "true"
-  tolerations: {}
+  tolerations: []
   budget:
     maxUnavailable: 1
   # strategy:
@@ -137,7 +137,7 @@ master:
   #   type: RollingUpdate
   #   rollingUpdate:
   #     partition: 1
-  tolerations: {}
+  tolerations: []
   budget:
     maxUnavailable: 1
   persistence:
@@ -177,7 +177,7 @@ data:
   #   type: RollingUpdate
   #   rollingUpdate:
   #     partition: 1
-  tolerations: {}
+  tolerations: []
   budget:
     maxUnavailable: 1
   persistence:


### PR DESCRIPTION
Tolerations is an array:

Replace `{}` by `[]`.

Avoid this warning:
```
helm upgrade --install elasticsearch cos/elasticsearch --namespace monitoring
2018/03/13 14:42:35 warning: cannot overwrite table with non table for tolerations (map[])
2018/03/13 14:42:35 warning: cannot overwrite table with non table for tolerations (map[])
2018/03/13 14:42:35 warning: cannot overwrite table with non table for tolerations (map[])
```