### PR TITLE
[SVCS-829] [OSF Preprints] Add Service Config For AfricArXiv Preprints

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name }}
 data:
 {{- define "cas.jetty.preprint-services" }}
+africarxiv:
+  id: '203948234207264'
+  name: 'AfricArXiv Preprints'
 agrixiv:
   id: '203948234207244'
   name: AgriXiv Preprints


### PR DESCRIPTION
### Ticket

https://openscience.atlassian.net/browse/SVCS-829

### Purpose

Add service config for AfricArXiv Preprints

### Deployment Notes

Must be merged and deployed before the CAS (PR-TBD)