### PR TITLE
[SVCS-858] [CAS] [OSF Registries] Add branded login support for OSF Registries

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -833,6 +833,52 @@ services/osf.json: |-
           }
       }
   }
+services/registries-osf.json: |-
+  {
+      "@class": "org.jasig.cas.services.RegexRegisteredService",
+      "id": 203948234207340,
+      "name": "",
+      "description": "",
+      "serviceId": "^https://{{ .Values.osfDomain | replace "." "\\\\." }}/login/?\\?next=https(%3A|:)(%2F|/)(%2F|/){{ .Values.osfDomain | replace "." "\\\\." }}(%2F|/)registries(%2F|/).*",
+      "logo": "https://{{ .Values.casDomain }}/images/registries-osf-logo-black.png",
+      "evaluationOrder": 1001,
+      "attributeReleasePolicy": {
+          "@class": "org.jasig.cas.services.ReturnAllowedAttributeReleasePolicy",
+          "allowedAttributes": [
+              "java.util.ArrayList", [
+                  "given-names",
+                  "family-name"
+              ]
+          ]
+      },
+      "properties": {
+          "@class": "java.util.HashMap",
+          "title": {
+              "@class": "org.jasig.cas.services.DefaultRegisteredServiceProperty",
+              "values": [
+                  "java.util.HashSet", [
+                      "Open Science Framework"
+                  ]
+              ]
+          },
+          "titleAbbr": {
+              "@class": "org.jasig.cas.services.DefaultRegisteredServiceProperty",
+              "values": [
+                  "java.util.HashSet", [
+                      "OSF"
+                  ]
+              ]
+          },
+          "registerUrl": {
+              "@class": "org.jasig.cas.services.DefaultRegisteredServiceProperty",
+              "values": [
+                  "java.util.HashSet", [
+                      "?campaign=osf-registries"
+                  ]
+              ]
+          }
+      }
+  }
 services/preprints-osf.json: |-
   {
       "@class": "org.jasig.cas.services.RegexRegisteredService",


### PR DESCRIPTION
### Ticket

https://openscience.atlassian.net/browse/SVCS-858

### Purpose

Add branded login support for OSF Registries.

![branded-login-osf-registries](https://user-images.githubusercontent.com/3750414/42475027-66a77194-8397-11e8-91b4-22dd01fdd62c.png)

### Changes

I copied what we have for OSF Preprints and updated the following:
* Entry name: `services/registries-osf.json`
* `"id"` (the unique ID for each service): 203948234207340
* `"serviceId"` (the URL matching regex for each service): `"^https://{{ .Values.osfDomain | replace "." "\\\\." }}/login/?\\?next=https(%3A|:)(%2F|/)(%2F|/){{ .Values.osfDomain | replace "." "\\\\." }}(%2F|/)registries(%2F|/).*"`
* `"logo"`: `"https://{{ .Values.casDomain }}/images/registries-osf-logo-black.png"`
* `"registerUrl"`: `"?campaign=osf-registries"`

@binoculars Please double check this make sense. Thanks.

### Deployment Notes

Need to redeploy CAS (after Helm Charts has been deployed) to load the new settings.