### PR TITLE
Use check_deploy_ready command to check if app is ready to deploy

### DIFF
--- a/osf/Chart.yaml
+++ b/osf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: The Open Science Framework (OSF)
 name: osf
-version: 0.15.2
+version: 0.15.3
 keywords:
   - open
   - science

--- a/osf/templates/admin-deployment.yaml
+++ b/osf/templates/admin-deployment.yaml
@@ -119,7 +119,7 @@ spec:
             - -c
             - |-
               set -e
-              gosu www-data python manage.py checkmigrations
+              gosu www-data python manage.py check_deploy_ready
               PREFIX=''
               if [ -f /code/newrelic.ini ]; then
                 PREFIX='newrelic-admin run-program'

--- a/osf/templates/api-deployment.yaml
+++ b/osf/templates/api-deployment.yaml
@@ -111,7 +111,7 @@ spec:
             - -c
             - |-
               set -e
-              gosu www-data python manage.py checkmigrations
+              gosu www-data python manage.py check_deploy_ready
               PREFIX=''
               if [ -f /code/newrelic.ini ]; then
                 PREFIX='newrelic-admin run-program'

--- a/osf/templates/beat-deployment.yaml
+++ b/osf/templates/beat-deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - -c
             - |-
               set -e
-              gosu www-data python manage.py checkmigrations
+              gosu www-data python manage.py check_deploy_ready
               PREFIX=''
               if [ -f /code/newrelic.ini ]; then
                 PREFIX='newrelic-admin run-program'

--- a/osf/templates/web-deployment.yaml
+++ b/osf/templates/web-deployment.yaml
@@ -165,7 +165,7 @@ spec:
             - -c
             - |-
               set -e
-              gosu www-data python manage.py checkmigrations
+              gosu www-data python manage.py check_deploy_ready
               PREFIX=''
               if [ -f /code/newrelic.ini ]; then
                 PREFIX='newrelic-admin run-program'


### PR DESCRIPTION
check_deploy_ready will delegate to other commands such as
checkmigrations to check if pods are ready to failover. This
will allow us to add more checks without having to change
these charts every time.

h/t @icereval for showing me where to make this change