### PR TITLE
Use sync_databases to run migrations and sync other DBs

### DIFF
--- a/osf/Chart.yaml
+++ b/osf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: The Open Science Framework (OSF)
 name: osf
-version: 0.15.3
+version: 0.15.4
 keywords:
   - open
   - science

--- a/osf/templates/migration-job.yaml
+++ b/osf/templates/migration-job.yaml
@@ -54,7 +54,7 @@ spec:
               if [ -f /code/newrelic.ini ]; then
                 PREFIX='newrelic-admin run-program'
               fi
-              $PREFIX python manage.py migrate
+              $PREFIX python manage.py sync_databases
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: api.base.settings


### PR DESCRIPTION
This command will be used to run both `python mangage.py migrate`
and `python manage.py sync_metrics` automatically on
staging environments.