### PR TITLE
[SVCS-949] Add MediArxiv to CAS branded sign-in

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -73,7 +73,7 @@ medarxiv:
   name: MedArXiv Preprints
 mediarxiv:
   id: '203948234207267'
-  name: MediArxiv Preprints
+  name: MediArXiv Preprints
   domain: mediarxiv.org
 mindrxiv:
   id: '203948234207250'

--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -71,6 +71,10 @@ marxiv:
 medarxiv:
   id: '203948234207256'
   name: MedArXiv Preprints
+mediarxiv:
+  id: '203948234207267'
+  name: MediArxiv Preprints
+  domain: mediarxiv.org
 mindrxiv:
   id: '203948234207250'
   name: MindRxiv Preprints


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-949

## Purpose and Deployment

- [ ] Must be deployed before: https://github.com/CenterForOpenScience/cas-overlay/pull/140
- [ ] Need to generate cert for mediarxiv.org
