### PR TITLE
Fix identation in echoheaders deployment

### DIFF
--- a/echoheaders/templates/deployment.yaml
+++ b/echoheaders/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          {{- if .Values.resources }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          {{- end }}
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}


### PR DESCRIPTION
Without those changes I get this error:
```
$ helm upgrade --install --debug --wait --namespace=default -f values-common.yaml -f values-dev.yaml echoheaders cos/echoheaders
[debug] Created tunnel using local port: '64831'

[debug] SERVER: "127.0.0.1:64831"

[debug] Fetched cos/echoheaders to /Users/kostyrev/.helm/cache/archive/echoheaders-0.1.0.tgz

Release "echoheaders" does not exist. Installing it now.
[debug] CHART PATH: /Users/kostyrev/.helm/cache/archive/echoheaders-0.1.0.tgz

Error: YAML parse error on echoheaders/templates/deployment.yaml: error converting YAML to JSON: yaml: line 40: did not find expected '-' indicator```