### PR TITLE
Fix spec.ports[0].targetPort template value

### DIFF
--- a/pgbouncer/templates/service.yaml
+++ b/pgbouncer/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.externalPort }}
-      targetPort: {{ .Values.service.name }}
+      targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
       name: {{ .Values.service.name }}
   selector:


### PR DESCRIPTION
Fix for error:
```
Error: UPGRADE FAILED: failed to create resource: Service "pgbouncer-pgbouncer" is invalid: spec.ports[0].targetPort: Invalid value: "pgbouncer"
```