### PR TITLE
Fix issue #43 mapping values are not allowed in this context 

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -5,12 +5,12 @@
 ## TL;DR;
 
 ```bash
-$ helm install stable/rabbitmq
+$ helm install rabbitmq
 ```
 
 ## Introduction
 
-This chart bootstraps a [RabbitMQ](https://github.com/bitnami/bitnami-docker-rabbitmq) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [RabbitMQ](https://hub.docker.com/_/rabbitmq) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ This chart bootstraps a [RabbitMQ](https://github.com/bitnami/bitnami-docker-rab
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/rabbitmq
+$ helm install --namespace mynamespace --name my-release rabbitmq
 ```
 
 The command deploys RabbitMQ on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -34,7 +34,7 @@ The command deploys RabbitMQ on the Kubernetes cluster in the default configurat
 To uninstall/delete the `my-release` deployment:
 
 ```bash
-$ helm delete my-release
+$ helm delete --purge my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -45,25 +45,24 @@ The following tables lists the configurable parameters of the RabbitMQ chart and
 
 |          Parameter          |                       Description                       |                         Default                          |
 |-----------------------------|---------------------------------------------------------|----------------------------------------------------------|
-| `image`                     | RabbitMQ image                                          | `bitnami/rabbitmq:{VERSION}`                             |
+| `image`                     | RabbitMQ image                                          | `rabbitmq:3-management`                                  |
 | `imagePullPolicy`           | Image pull policy                                       | `Always` if `imageTag` is `latest`, else `IfNotPresent`. |
-| `rabbitmqUsername`          | RabbitMQ application username                           | `user`                                                   |
-| `rabbitmqPassword`          | RabbitMQ application password                           | _random 10 character long alphanumeric string_           |
-| `rabbitmqErlangCookie`      | Erlang cookie                                           | _random 32 character long alphanumeric string_           |
+| `rabbitmqUsername`          | RabbitMQ application username                           | `quantex`                                                |
+| `rabbitmqPassword`          | RabbitMQ application password                           | `quantex@123`                                            |
+| `rabbitmqErlangCookie`      | Erlang cookie                                           | `cookie`                                                 |
 | `rabbitmqNodePort`          | Node port                                               | `5672`                                                   |
 | `rabbitmqNodeType`          | Node type                                               | `stats`                                                  |
-| `rabbitmqNodeName`          | Node name                                               | `rabbit`                                                 |
+| `rabbitmqNodeName`          | Node name                                               | ``                                                       |
 | `rabbitmqClusterNodeName`   | Node name to cluster with. e.g.: `clusternode@hostname` | `nil`                                                    |
 | `rabbitmqVhost`             | RabbitMQ application vhost                              | `/`                                                      |
 | `rabbitmqManagerPort`       | RabbitMQ Manager port                                   | `15672`                                                  |
-| `serviceType`               | Kubernetes Service type                                 | `ClusterIP`                                              |
+| `service.type`              | Kubernetes Service type                                 | `Nodeport`                                               |
 | `persistence.enabled`       | Use a PVC to persist data                               | `true`                                                   |
 | `persistence.existingClaim` | Use an existing PVC to persist data                     | `nil`                                                    |
-| `persistence.storageClass`  | Storage class of backing PVC                            | `nil` (uses alpha storage class annotation)              |
+| `persistence.storageClass`  | Storage class of backing PVC                            | `nfs-client`                                             |
 | `persistence.accessMode`    | Use volume as ReadOnly or ReadWrite                     | `ReadWriteOnce`                                          |
 | `persistence.size`          | Size of data volume                                     | `8Gi`                                                    |
 
-The above parameters map to the env variables defined in [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq). For more information please refer to the [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -78,14 +77,12 @@ The above command sets the RabbitMQ admin username and password to `admin` and `
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/rabbitmq
+$ helm install --name my-release -f values.yaml rabbitmq
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## Persistence
-
-The [Bitnami RabbitMQ](https://github.com/bitnami/bitnami-docker-rabbitmq) image stores the RabbitMQ data and configurations at the `/bitnami/rabbitmq` path of the container.
 
 The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. By default, the volume is created using dynamic volume provisioning. An existing PersistentVolumeClaim can also be defined.
 

--- a/rabbitmq/templates/configmap.yaml
+++ b/rabbitmq/templates/configmap.yaml
@@ -20,12 +20,6 @@ RABBITMQ_SSL_CACERTFILE: /etc/ssl/ca_certificate.pem
   {{ $key }}: {{ $value | quote }}
   {{- end }}
 
-  {{- /* Metrics */ -}}
-  {{- if .Values.metrics.enabled }}
-  {{- range $key, $value := .Values.metrics.configEnvs }}
-  metrics-{{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
 
   {{- /* Configuration Files */ -}}
   {{- range $key, $value := .Values.configFiles }}

--- a/rabbitmq/templates/service-headless.yaml
+++ b/rabbitmq/templates/service-headless.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}-headless
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  ports:
+    {{- range $name, $port := .Values.service.ports }}
+    - name: {{ $name }}
+      port: {{ $port }}
+      protocol: TCP
+      targetPort: {{ $name }}
+    {{- end }}
+  selector:
+    app: {{ template "rabbitmq.name" . }}
+    release: {{ .Release.Name }}

--- a/rabbitmq/templates/statefulset.yaml
+++ b/rabbitmq/templates/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   serviceName: {{ template "rabbitmq.fullname" . }}
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -38,22 +38,22 @@ spec:
             - name: {{ $name }}
               containerPort: {{ $port }}
             {{- end }}
-          #livenessProbe:
-          #  exec:
-          #    command:
-          #      - rabbitmqctl
-          #      - status
-          #  initialDelaySeconds: 120
-          #  timeoutSeconds: 5
-          #  failureThreshold: 6
-          #readinessProbe:
-          #  exec:
-          #    command:
-          #      - rabbitmqctl
-          #      - status
-          #  initialDelaySeconds: 10
-          #  timeoutSeconds: 3
-          #  periodSeconds: 5
+          livenessProbe:
+           exec:
+             command:
+               - rabbitmqctl
+               - status
+           initialDelaySeconds: 120
+           timeoutSeconds: 5
+           failureThreshold: 6
+          readinessProbe:
+           exec:
+             command:
+               - rabbitmqctl
+               - status
+           initialDelaySeconds: 10
+           timeoutSeconds: 3
+           periodSeconds: 5
           volumeMounts:
             {{- include "rabbitmq.volumeMounts" . | indent 12 }}
           {{- if .Values.resources }}
@@ -86,14 +86,6 @@ spec:
                 configMapKeyRef:
                   name: {{ $fullname }}
                   key: RABBITMQ_SSL_CACERTFILE
-            {{- end }}
-            {{- $fullname := include "rabbitmq.fullname" . -}}
-            {{- range $key := keys .Values.metrics.configEnvs }}
-            - name: {{ $key }}
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ $fullname }}
-                  key: metrics-{{ $key }}
             {{- end }}
           ports:
             - name: metrics

--- a/rabbitmq/templates/statefulset.yaml
+++ b/rabbitmq/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           env:
-            {{- $fullname := include "rabbitmq.fullname" . -}}
+            {{- $fullname := include "rabbitmq.fullname" . }}
             - name: RABBIT_URL
               value: http{{- if .Values.tls.enabled -}}s{{- end -}}://localhost:{{- .Values.service.ports.stats }}
             - name: RABBIT_USER

--- a/rabbitmq/values.yaml
+++ b/rabbitmq/values.yaml
@@ -6,6 +6,8 @@ image:
   tag: 3-management
   pullPolicy: IfNotPresent
 
+replicas: 1
+
 additionalAffinities: {}
 
 terminationGracePeriodSeconds: 60
@@ -21,9 +23,9 @@ configFiles: {}
 
 secretEnvs:
   ## ref: https://hub.docker.com/_/rabbitmq/
-  RABBITMQ_DEFAULT_USER: guest
+  RABBITMQ_DEFAULT_USER: quantex
   ## ref: https://hub.docker.com/_/rabbitmq/
-  RABBITMQ_DEFAULT_PASS: guest
+  RABBITMQ_DEFAULT_PASS: quantex@123
   ## Erlang cookie to determine whether different nodes are allowed to communicate with each other
   RABBITMQ_ERLANG_COOKIE: cookie
 
@@ -71,13 +73,13 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: ssd
+  storageClass: "nfs-client"
   accessMode: ReadWriteOnce
   size: 8Gi
 
 service:
   #annotations: {}
-  type: ClusterIP
+  type: NodePort
   # If using type: LoadBalancer
   #loadBalancerIP: 0.0.0.0
   #loadBalancerSourceRanges:
@@ -91,23 +93,11 @@ service:
   externalIPs: []
 
 metrics:
-  enabled: false
+  enabled: true
   image:
+    registry: docker.io
     repository: kbudde/rabbitmq-exporter
     tag: v0.25.2
     pullPolicy: IfNotPresent
-  configEnvs:
-    # Log ouput format. TTY and JSON are suported
-    OUTPUT_FORMAT: TTY
-    # log level. possible values: "debug", "info", "warning", "error", "fatal", or "panic"
-    LOG_LEVEL: info
-    # true/0 will ignore certificate errors of the management plugin
-    SKIPVERIFY: false	
-    # reqgex queue filter. just matching names are exported
-    INCLUDE_QUEUES: .*
-    # regex, matching queue names are not exported (useful for short-lived rpc queues). First performed INCLUDE, after SKIP
-    SKIP_QUEUES: ^$
-    # comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
-    RABBIT_CAPABILITIES: bert
-    # List of enabled modules. Just "connections" is not enabled by default
-    RABBIT_EXPORTERS: exchange,node,overview,queue
+  
+  resources: {}


### PR DESCRIPTION
This PR will fix issue #43.

The  `-}}` would make a wrong format in `env:- name: RABBIT_URL`. ( That `-}}` would delete all blank include '\n' in the right  )

```- name: metrics
          image: "kbudde/rabbitmq-exporter:v0.25.2"
          imagePullPolicy: IfNotPresent
          env:- name: RABBIT_URL
              value: http://localhost:15672
            - name: RABBIT_USER
              valueFrom:
                secretKeyRef:
                  name: left-manta-rabbitmq
                  key: RABBITMQ_DEFAULT_USER
            - name: RABBIT_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: left-manta-rabbitmq
                  key: RABBITMQ_DEFAULT_PASS
            - name: PUBLISH_PORT
              value: 9090
```

after remove `-}}`

``` - name: metrics
          image: "kbudde/rabbitmq-exporter:v0.25.2"
          imagePullPolicy: IfNotPresent
          env:
            - name: RABBIT_URL
              value: http://localhost:15672
            - name: RABBIT_USER
              valueFrom:
                secretKeyRef:
                  name: dandy-raccoon-rabbitmq
                  key: RABBITMQ_DEFAULT_USER
            - name: RABBIT_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: dandy-raccoon-rabbitmq
                  key: RABBITMQ_DEFAULT_PASS
            - name: PUBLISH_PORT
              value: 9090
```

