### PR TITLE
Fix issue #43 mapping values are not allowed in this context

### DIFF
--- a/rabbitmq/templates/statefulset.yaml
+++ b/rabbitmq/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           env:
-            {{- $fullname := include "rabbitmq.fullname" . -}}
+            {{- $fullname := include "rabbitmq.fullname" . }}
             - name: RABBIT_URL
               value: http{{- if .Values.tls.enabled -}}s{{- end -}}://localhost:{{- .Values.service.ports.stats }}
             - name: RABBIT_USER
@@ -87,7 +87,6 @@ spec:
                   name: {{ $fullname }}
                   key: RABBITMQ_SSL_CACERTFILE
             {{- end }}
-            {{- $fullname := include "rabbitmq.fullname" . -}}
             {{- range $key := keys .Values.metrics.configEnvs }}
             - name: {{ $key }}
               valueFrom:


### PR DESCRIPTION
This PR will fix issue #43.

The  `-}}` would make a wrong format in `env:- name: RABBIT_URL`. ( That `-}}` would delete all blank include '\n' in the right  )

```- name: metrics
          image: "kbudde/rabbitmq-exporter:v0.25.2"
          imagePullPolicy: IfNotPresent
          env:- name: RABBIT_URL
              value: http://localhost:15672
            - name: RABBIT_USER
              valueFrom:
                secretKeyRef:
                  name: left-manta-rabbitmq
                  key: RABBITMQ_DEFAULT_USER
            - name: RABBIT_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: left-manta-rabbitmq
                  key: RABBITMQ_DEFAULT_PASS
            - name: PUBLISH_PORT
              value: 9090
```

after remove `-}}`

``` - name: metrics
          image: "kbudde/rabbitmq-exporter:v0.25.2"
          imagePullPolicy: IfNotPresent
          env:
            - name: RABBIT_URL
              value: http://localhost:15672
            - name: RABBIT_USER
              valueFrom:
                secretKeyRef:
                  name: dandy-raccoon-rabbitmq
                  key: RABBITMQ_DEFAULT_USER
            - name: RABBIT_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: dandy-raccoon-rabbitmq
                  key: RABBITMQ_DEFAULT_PASS
            - name: PUBLISH_PORT
              value: 9090
```