### PR TITLE
bump LO version in unoconv container start command

### DIFF
--- a/mfr/templates/deployment.yaml
+++ b/mfr/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
           command:
             - gosu
             - www-data
-            - /opt/libreoffice6.0/program/python
+            - /opt/libreoffice6.1/program/python
             - -u
             - /usr/local/bin/unoconv
             - --listener


### PR DESCRIPTION
 * We're upgrading to LibreOffice v6.1.5 since the old release archive
   is currently unavailable.