### PR TITLE
[OSF Preprints] EdArXiv Branded Login [ENG-377]

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -41,6 +41,9 @@ ecsarxiv:
   id: '203948234207259'
   name: ECSarXiv Preprints
   domain: ecsarxiv.org
+edarxiv:
+  id: '203948234207270'
+  name: EdArXiv Preprints
 engrxiv:
   id: '203948234207242'
   name: engrXiv Preprints


### PR DESCRIPTION
### Purpose

Add  EdArXiv to CAS branded sign-in.

### DevOps Notes

Must be deployed before: https://github.com/CenterForOpenScience/cas-overlay/pull/149

### Ticket

https://openscience.atlassian.net/browse/ENG-377
