### PR TITLE
[OSF Preprints] IndiaRxiv Branded Login [ENG-579]

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -61,6 +61,10 @@ frenxiv:
 inarxiv:
   id: '203948234207257'
   name: INA-Rxiv Preprints
+indiarxiv:
+  id: '203948234207271'
+  name: IndiaRxiv Preprints
+  domain: indiarxiv.org
 lawarxiv:
   id: '203948234207247'
   name: LawArXiv Papers


### PR DESCRIPTION
### Purpose

Add  IndiaRxiv to CAS branded sign-in.

### DevOps Notes

- [ ] IndiaRxiv needs to fix their DNAS to CNAME osf.io

- [ ] Generate CERT for branded domain `indiarxiv.org` ![lets-encrypt](https://user-images.githubusercontent.com/3750414/58975975-573c7400-8794-11e9-9ff5-9c713bec0067.png)

- [ ] Either deploy HC before https://github.com/CenterForOpenScience/cas-overlay/pull/150 or re-deploy CAS if after.

### Ticket

https://openscience.atlassian.net/browse/ENG-579
