### PR TITLE
[OSF Preprints] Branded Domain For EdArXiv [ENG-597]

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -44,6 +44,7 @@ ecsarxiv:
 edarxiv:
   id: '203948234207270'
   name: EdArXiv Preprints
+  domain: edarxiv.org
 engrxiv:
   id: '203948234207242'
   name: engrXiv Preprints


### PR DESCRIPTION
### Purpose

EdArXiv Preprints wants to use a customized domain: `edarxiv.org`.

- [x] DNS not setup yet. `host` returns empty and `traceroute` says "unknown host". ![lets-encrypt](https://user-images.githubusercontent.com/3750414/59603251-f471a380-90d6-11e9-9c35-121a34330058.png)

- [x] Just the domain update, no ![cas](https://user-images.githubusercontent.com/3750414/59603235-e1f76a00-90d6-11e9-8634-831b11815844.png) this time.

### Ticket

New: https://openscience.atlassian.net/browse/ENG-597
Old: https://openscience.atlassian.net/browse/ENG-377
