### PR TITLE
[ENG-1271] [OSF Preprints] Branded Sign-in for BioHackrXiv 

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -23,6 +23,10 @@ arabixiv:
 banglarxiv:
   id: '203948234207266'
   name: Banglarxiv Preprints
+biohackrxiv:
+  id: '203948234207272'
+  name: BioHackrXiv Preprints
+  domain: biohackrxiv.org
 bitss:
   id: '203948234207245'
   name: BITSS Preprints


### PR DESCRIPTION
## Purpose

Add  BioHackrXiv to CAS branded sign-in.

## DevOps Notes

- [x] BioHackrXiv needs to fix their DNS

- [ ] Generate CERT for branded domain `biohackrxiv.org`

- [ ] Update CORS whitelist.

- [ ] After this PR has been merged and helm charts has been successfully built, deploy the CAS hot-fix https://github.com/CenterForOpenScience/cas-overlay/pull/173

## Ticket

https://openscience.atlassian.net/browse/ENG-1271