### PR TITLE
[No Ticket] Update `cas.properties` to use SYS ENV for OSF DB dialect

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -418,11 +418,11 @@ cas.properties: |-
   ##
   # Open Science Framework Postgres Database
   #
-  osf.database.driverClass=org.postgresql.Driver
+  osf.database.driverClass=${OSF_DB_DRIVERCLASS:org.postgresql.Driver}
   osf.database.url=${OSF_DB_URL:jdbc:postgresql://127.0.0.1/osf?targetServerType=master}
   osf.database.user=${OSF_DB_USER:postgres}
   osf.database.password=${OSF_DB_PASSWORD:}
-  osf.database.hibernate.dialect=org.hibernate.dialect.PostgreSQL82Dialect
+  osf.database.hibernate.dialect=${OSF_DB_HIBERNATE_DIALECT:org.hibernate.dialect.PostgreSQL82Dialect}
 
   ##
   # OAuth Provider


### PR DESCRIPTION
### Related CAS PR and Ticket

* PR: https://github.com/CenterForOpenScience/cas-overlay/pull/168
* Ticket: https://openscience.atlassian.net/browse/ENG-1134

### Purpose

* Use system environment variables when configuring `osf.database.hibernate.dialect` so that staging, test and prod servers can have different dialect. This is required by https://github.com/CenterForOpenScience/cas-overlay/pull/168.

### Side-effect

* Updated `osf.database.driverClass` as well (to make all OSF DB settings look consistent).

### DevOps Note

* This PR blocks https://github.com/CenterForOpenScience/cas-overlay/pull/168.
* This PR can be merged without causing any effect until an ENV is added to the server OS and the server is redeployed.
