### PR TITLE
[No Ticket] Update CAS's default hibernate dialect for OSF database

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -422,7 +422,7 @@ cas.properties: |-
   osf.database.url=${OSF_DB_URL:jdbc:postgresql://127.0.0.1/osf?targetServerType=master}
   osf.database.user=${OSF_DB_USER:postgres}
   osf.database.password=${OSF_DB_PASSWORD:}
-  osf.database.hibernate.dialect=${OSF_DB_HIBERNATE_DIALECT:org.hibernate.dialect.PostgreSQL82Dialect}
+  osf.database.hibernate.dialect=${OSF_DB_HIBERNATE_DIALECT:io.cos.cas.adaptors.postgres.hibernate.OSFPostgreSQLDialect}
 
   ##
   # OAuth Provider


### PR DESCRIPTION
### Purpose

Update CAS's default hibernate dialect for OSF database.

### DevOps Note

No effect and no need to redeploy CAS.