### PR TITLE
[ENG-1415] [OSF Preprints] Branded Sign-in for HSRxiv

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -63,6 +63,9 @@ frenxiv:
   id: '203948234207263'
   name: Frenxiv Preprints
   domain: frenxiv.org
+hsrxiv:
+  id: '203948234207273'
+  name: HSRxiv Preprints
 inarxiv:
   id: '203948234207257'
   name: INA-Rxiv Preprints


### PR DESCRIPTION
## Purpose

Add  HSRxiv to CAS branded sign-in.

## DevOps Notes

- Customized Domain: N / A

- [ ] This PR must be merged and new charts must be built before https://github.com/CenterForOpenScience/cas-overlay/pull/177

## Ticket

https://openscience.atlassian.net/browse/ENG-1415