### PR TITLE
[Supporting ENG-810] CAS settings for Institution SSO with Concordia College

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -386,6 +386,12 @@ cas.properties: |-
   cas.callutheran.client.name=${CAS_CALLUTHERAN_CLIENT_NAME:callutheran}
   cas.callutheran.cas.protocol=${CAS_CALLUTHERAN_CAS_PROTOCOL:SAML}
   #
+  # CAS Client: Concordia College
+  cas.cord.login.url=${CAS_CORD_LOGIN_URL:https://bprdeis.cord.edu:8443/cas/login}
+  cas.cord.prefix.url=${CAS_CORD_PREFIX_URL:https://bprdeis.cord.edu:8443/cas/}
+  cas.cord.client.name=${CAS_CORD_CLIENT_NAME:cord}
+  cas.cord.cas.protocol=${CAS_CORD_CAS_PROTOCOL:SAML}
+  #
   # CAS Client: Oklahoma State University
   cas.okstate.login.url=${CAS_OKSTATE_LOGIN_URL:https://stwcas.okstate.edu/cas/login}
   cas.okstate.prefix.url=${CAS_OKSTATE_PREFIX_URL:https://stwcas.okstate.edu/cas/}


### PR DESCRIPTION
### Purpose

Update `cas.properties` for Concordia College

### DevOps Notes: _Both Test and Prod Servers_

- [ ] Merge the charts and wait for it to build
- [ ] Update **Jetty** server settings and add the following piece to the  **CAS part** of the `institutions-auth.xsl` file.

```xml
<!-- Concordia College (CORD) -->
<xsl:when test="$idp='cord'">
    <id>cord</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
        <familyName />
        <givenName />
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```
- [ ] Merge and Deploy CAS
- [ ] Merge and Deploy OSF
- [ ] Run the institution population script to add Concordia
- [ ] For now, ignore the domain (either alias or redirect), they don't have it.

### Related Tickets and PRs

* Ticket: https://openscience.atlassian.net/browse/ENG-810
* CAS PR: https://github.com/CenterForOpenScience/cas-overlay/pull/178
* OSF PR: https://github.com/CenterForOpenScience/osf.io/pull/9279