### PR TITLE
[ENG-2005] Update logging level for CAS

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -673,15 +673,51 @@ log4j2.xml: |-
           </Raven>
       </Appenders>
       <Loggers>
-          <Logger name="io.cos" level="info" additivity="false">
+          <!-- OSF CAS -->
+          <Logger name="io.cos" level="debug" additivity="false">
               <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
           </Logger>
+          <!-- Jasig / Apereo -->
           <Logger name="org.jasig" level="info" additivity="false">
               <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
           </Logger>
+          <Logger name="org.jasig.cas" level="debug" additivity="false">
+              <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
+          </Logger>
+          <Logger name="org.jasig.cas.services.DefaultServicesManagerImpl" level="info" additivity="false">
+              <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
+          </Logger>
+          <Logger name="org.jasig.cas.web.support.InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter" level="info" additivity="false">
+              <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
+          </Logger>
+          <!-- Pac4j -->
+          <Logger name="org.pac4j" level="debug" additivity="false">
+              <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
+          </Logger>
+          <!-- Spring Framework -->
+          <Logger name="org.springframework" level="info" additivity="false">
+              <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
+          </Logger>
+          <Logger name="org.springframework.web.servlet" level="debug" additivity="false">
+              <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
+          </Logger>
+          <Logger name="org.springframework.webflow" level="debug" additivity="false">
+              <AppenderRef ref="Console" />
+              <AppenderRef ref="Sentry" />
+          </Logger>
+          <!-- perfStats is turned off to disable chatty metrics -->
           <Logger name="perfStatsLogger" level="off" additivity="false">
               <AppenderRef ref="Console" />
           </Logger>
+          <!-- Root logging level is set to "warn" -->
           <Root level="warn">
               <AppenderRef ref="Console" />
               <AppenderRef ref="Sentry" />


### PR DESCRIPTION
### Ticket

https://openscience.atlassian.net/browse/ENG-2005

### Purpose

Update / fix CAS logging to debug OKState logging issue. `debug` level has been turned on for

* `io.cos`
* `org.jasig.cas`
* `org.pac4j`
* `org.springframework.web.servlet`
* `org.springframework.webflow`

### Side Effect

Somehow `sentry` was configured but not enabled. This has been fixed.

### Deployment Notes

@mfraezz Let's deploy the `staging` and `test` servers first. I will check the logs before `prod` deployment.