### PR TITLE
[Support ENG-2171] Add timeout setting for CAS ORCID login

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -401,6 +401,8 @@ cas.properties: |-
   oauth.orcid.client.secret=${OAUTH_ORCID_CLIENT_SECRET:}
   oauth.orcid.member=${OAUTH_ORCID_MEMBER:false}
   oauth.orcid.scope=${OAUTH_ORCID_SCOPE:/authenticate}
+  oauth.orcid.connect.timeout=${OAUTH_CONNECT_TIMEOUT:10000}
+  oauth.orcid.read.timeout=${OAUTH_READ_TIMEOUT:60000}
 
   ##
   # OSF URLs


### PR DESCRIPTION
## Notes

- Default values are provided so it is optional to set system ENVs
  - Connection timeout is 10 sec
  - Read timeout is 1 min

- [ ] Blocks https://github.com/CenterForOpenScience/cas-overlay/pull/188
