### PR TITLE
[No Ticket] Add URLs to cas.properties for institution SSO bridge / migration

### DIFF
--- a/cas/templates/configmap.yaml
+++ b/cas/templates/configmap.yaml
@@ -358,6 +358,7 @@ cas.properties: |-
   cas.osf.login.url=/login?
   cas.logout.url=/logout
   cas.institution.login.url=/login?campaign=institution
+  cas.institution.unsupported.url=/login?campaign=unsupportedinstitution
 
   ##
   # Login Rate Limiting
@@ -411,7 +412,9 @@ cas.properties: |-
   osf.institutionLogin.url=https://{{ .Values.osfDomain }}/login/?campaign=institution
   osf.resendConfirmation.url=https://{{ .Values.osfDomain }}/resend/
   osf.forgotPassword.url=https://{{ .Values.osfDomain }}/forgotpassword/
+  osf.forgotPasswordInstitution.url=https://{{ .Values.osfDomain }}/forgotpassword-institution/
   osf.createAccount.url=https://{{ .Values.osfDomain }}/register/
+  osf.osfi.url=https://{{ .Values.osfDomain }}/institutions/
 
   ##
   # API URLs


### PR DESCRIPTION
## Tickets / PRs

Supports [ENG-2241](https://openscience.atlassian.net/browse/ENG-2241) with [oldCAS-#195](https://github.com/CenterForOpenScience/cas-overlay/pull/195) and [OSF-#9606](https://github.com/CenterForOpenScience/osf.io/pull/9606).

## Notes

Merge and build. This one does not break existing oldCAS and thus is not blocked by the two PRs above.