### PR TITLE
Fill celery-flower command arguments from values

### DIFF
--- a/flower/templates/deployment.yaml
+++ b/flower/templates/deployment.yaml
@@ -25,8 +25,8 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: 
         - flower
-        - --broker
-        - amqp://guest:guest@rabbitmq:5672//
+        - --port={{ .Values.service.internalPort }}
+        - --broker={{ .Values.command.broker }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/flower/values.yaml
+++ b/flower/values.yaml
@@ -36,3 +36,6 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
+
+command:
+  broker: amqp://guest:guest@rabbitmq:5672//


### PR DESCRIPTION
There are two changes in this PR:

1. Internal port. Currently, you may change `service.internalPort` in Values, but flower always starts with the default port. I think it is a good idea to provide a proper port as flower command argument.
2. The broker value is hardcoded. It looks like a common practice to provide your own broker: it could be other credentials to RabbitMQ or maybe you may want to use Redis instead of RabbitMQ. I moved the broker argument to `.Values.command.broker`, so you may override it.