### PR TITLE
update share worker invocation for celery upgrade

### DIFF
--- a/share/Chart.yaml
+++ b/share/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: SHARE
 name: share
-version: 0.3.0
+version: 0.4.0
 keywords:
   - open
   - science

--- a/share/templates/worker-deployment.yaml
+++ b/share/templates/worker-deployment.yaml
@@ -62,7 +62,7 @@ spec:
               if [ -f /code/newrelic.ini ]; then
                 PREFIX='newrelic-admin run-program'
               fi
-              $PREFIX gosu www-data celery worker --app project \
+              $PREFIX gosu www-data celery --app project worker \
                 --concurrency "{{ .Values.worker.concurrency }}" --loglevel "{{ .Values.worker.logLevel }}" \
                 --hostname $POD_NAME --without-gossip -Ofair
                 {{- if .Values.worker.maxTasksPerChild }} --maxtasksperchild "{{ .Values.worker.maxTasksPerChild }}"{{- end }}


### PR DESCRIPTION
the `--app` arg must go before the `worker` command in celery 5:
`celery worker --app project ...` => `celery --app project worker ...`

required for deploying https://github.com/CenterForOpenScience/SHARE/pull/788