### PR TITLE
[ENG-3263][ENG-3302][ENG-3304] Update OAuth server token expiration policy; update GA Tech department attribute

### DIFF
--- a/osf-cas/templates/configmap.yaml
+++ b/osf-cas/templates/configmap.yaml
@@ -588,9 +588,9 @@ config/cas.properties: |-
   cas.authn.oauth.code.number-of-uses=1
   #
   # Access token
-  #
-  cas.authn.oauth.access-token.time-to-kill-in-seconds=7200
-  cas.authn.oauth.access-token.max-time-to-live-in-seconds=28800
+  # Both time-to-kill and max-time-to-live must be set the same since the OAuth 2.0 protocol only defines one
+  cas.authn.oauth.access-token.time-to-kill-in-seconds=3600
+  cas.authn.oauth.access-token.max-time-to-live-in-seconds=3600
   #
   # OAuth JWT Access Tokens
   # Signing and encryption are not enabled for Token / JWT Tickets.
@@ -604,11 +604,11 @@ config/cas.properties: |-
   #
   # Refresh token
   #
-  cas.authn.oauth.refresh-token.time-to-kill-in-seconds=2592000
+  cas.authn.oauth.refresh-token.time-to-kill-in-seconds=7776000
   #
   # Personal access token
   #
-  cas.authn.oauth.personal-access-token.time-to-kill-in-seconds=2592000
+  cas.authn.oauth.personal-access-token.time-to-kill-in-seconds=31104000
   cas.authn.oauth.personal-access-token.max-time-to-live-in-seconds=31104000
   #
   # Signing and encryption for OAuth registered service


### PR DESCRIPTION
### What

See https://openscience.atlassian.net/browse/ENG-3302 and https://openscience.atlassian.net/browse/ENG-3304 for details.

Update expiration policy for tokens and "disable" time-to-kill 

* Access token: 1 hour
* Refresh token: 90 days
* Personal access token (CAS copy of the OSF one): 1 year
* Set time-to-kill (active window) and max-time-to-live (max life)to the same value

### Extra

See https://openscience.atlassian.net/browse/ENG-3263

GA Tech Department attribute update (private config). For both `prod` and `test` Shibboleth server,replace the following "friendly name"

```
<Attribute name="gtEmployeeHomeDepartmentName" id="department"/>
```

with the correct URN

```
<Attribute name="urn:oid:1.3.6.1.4.1.636.2.11.1.56" id="department"/>
```

in `attribute-map.xml`.

### DevOps Notes

@mfraezz 

Merge and rebuild the chart. Then redeploy CAS.