### PR TITLE
[ENG-3583] Bump TGT expiration policy

### DIFF
--- a/osf-cas/templates/configmap.yaml
+++ b/osf-cas/templates/configmap.yaml
@@ -532,10 +532,12 @@ config/cas.properties: |-
   cas.tgc.remember-me-max-age=P28D
   cas.tgc.auto-configure-cookie-path=true
   #
-  # Ticket Granting Ticket Persistence Settings
+  # Ticket Granting Ticket Settings
   #
+  cas.ticket.tgt.max-time-to-live-in-seconds=7776000
+  cas.ticket.tgt.time-to-kill-in-seconds=7776000
   cas.ticket.tgt.remember-me.enabled=true
-  cas.ticket.tgt.remember-me.time-to-kill-in-seconds=7200
+  cas.ticket.tgt.remember-me.time-to-kill-in-seconds=7776000
   ########################################################################################################################
 
   ########################################################################################################################


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-3583

## Purpose & Changes

@mfraezz

Bump TGT expiration time to 90 days (7776000 in seconds) so that related ATs and RTs won't get deleted before their own expiration time. This is a temporary solution. See more details in the [ticket](https://openscience.atlassian.net/browse/ENG-3583).

Don't deploy on prod until staging or test is verified. Verification takes two hours.

## Note

This one doesn't solve the design limitation (for better security) of TGT deletion caused by signing out of CAS. However, this is not common during "log in with OSF".
