### PR TITLE
[ENG-3773] Enable CAS health endpoint for K8s probing

### DIFF
--- a/osf-cas/templates/configmap.yaml
+++ b/osf-cas/templates/configmap.yaml
@@ -355,6 +355,16 @@ config/cas.properties: |-
   ########################################################################################################################
 
   ########################################################################################################################
+  # CAS Monitoring & Statistics Endpoints
+  # See: https://apereo.github.io/cas/6.2.x/monitoring/Monitoring-Statistics.html
+  ########################################################################################################################
+  management.endpoints.web.exposure.include=health
+  management.endpoint.health.enabled=true
+  management.endpoint.health.show-details=WHEN_AUTHORIZED
+  cas.monitor.endpoints.endpoint.health.access=ANONYMOUS
+  ########################################################################################################################
+
+  ########################################################################################################################
   # CAS Web Application Endpoints Security
   # See: https://docs.spring.io/spring-boot/docs/2.2.8.RELEASE/reference/htmlsingle/#boot-features-security
   # Currently, no sensitive endpoint is exposed. However, set them to prevent auto-generated and logged password


### PR DESCRIPTION
## Purpose

Enable the `/actuator/health` endpoint for K8s liveness probing.

For details, refer to the [CAS PR](https://github.com/CenterForOpenScience/osf-cas/pull/62)

- [ ] Must be merged by before the CAS deployment.