### PR TITLE
Add CoP Preprints to CAS Branded Login

### DIFF
--- a/osf-cas/templates/configmap.yaml
+++ b/osf-cas/templates/configmap.yaml
@@ -29,6 +29,9 @@ bitss:
 bodoarxiv:
   id: '203948234207268'
   name: BodoArXiv Preprints
+coppreprints:
+  id: '203948234207274'
+  name: CoP Preprints
 eartharxiv:
   id: '203948234207261'
   name: EarthArXiv Preprints


### PR DESCRIPTION
## Purpose

Add CoP Preprints to CAS Branded Login

## DevOps Notes

- [ ] CAS PR needs to be merged / deployed after charts update