### PR TITLE
Trim  institution CAS clients due to okstate cas-to-saml migration

### DIFF
--- a/osf-cas/templates/configmap.yaml
+++ b/osf-cas/templates/configmap.yaml
@@ -569,7 +569,6 @@ config/cas.properties: |-
   # Institution clients
   #
   cas.authn.osf-postgres.institution-clients[0]=${cas.authn.pac4j.cas[0].client-name}
-  cas.authn.osf-postgres.institution-clients[1]=${cas.authn.pac4j.cas[1].client-name}
   #
   # Delegation Client: ORCiD
   #


### PR DESCRIPTION
## Purpose

We happen to left out one config where defines how many CAS clients are configured. This lead to CAS mistakenly configuring an extra clients. This doesn't break CAS and but needs to be fixed. Here is how is looks like locally (`test` and `prod` don't have `osftype0`)

```
INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <cord>                                                                                                                                                                                                                                                      
INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <osftype0>                                                                                                                                                                                                                                                  
INFO [io.cos.cas.osf.web.flow.login.OsfPrincipalFromNonInteractiveCredentialsAction] - <${cas.authn.pac4j.cas[2].client-name}>
```

## DevOps Notes

No need to redeploy CAS since this bug doesn't break CAS.