### PR TITLE
[ENG-7225] update share indexer command

### DIFF
--- a/share/templates/indexer-deployment.yaml
+++ b/share/templates/indexer-deployment.yaml
@@ -62,7 +62,7 @@ spec:
               if [ -f /code/newrelic.ini ]; then
                 PREFIX='newrelic-admin run-program'
               fi
-              $PREFIX gosu www-data sharectl search daemon
+              $PREFIX gosu www-data python manage.py shtrove_indexer_run
           env:
             {{- include "share.environment" . | nindent 12 }}
             {{- range $key, $value := .Values.indexer.env }}


### PR DESCRIPTION
`sharectl` was removed in favor of django management commands; see https://github.com/CenterForOpenScience/SHARE/pull/849